### PR TITLE
fix unsecure padding scheme

### DIFF
--- a/Math/BigInteger.php
+++ b/Math/BigInteger.php
@@ -1701,7 +1701,7 @@ class Math_BigInteger
 
             $plaintext = str_pad($this->toBytes(), strlen($n->toBytes(true)) - 1, "\0", STR_PAD_LEFT);
 
-            if (openssl_public_encrypt($plaintext, $result, $RSAPublicKey, OPENSSL_NO_PADDING)) {
+            if (openssl_public_encrypt($plaintext, $result, $RSAPublicKey, OPENSSL_PKCS1_OAEP_PADDING)) {
                 return new Math_BigInteger($result, 256);
             }
         }


### PR DESCRIPTION
## Description

Here RSA is used with not padding. Using ` OPENSSL_NO_PADDING` makes the function vulnerable to a chosen-ciphertext attack.

## References

- [CWE-327 - Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327)
- [A02:2021 – Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
- [PHP - openssl_public_encrypt](https://www.php.net/manual/en/function.openssl-public-encrypt)
- [Chosen Ciphertext Attacks Against Protocols Based on the RSA Encryption Standard PKCS #1](https://archiv.infsec.ethz.ch/education/fs08/secsem/bleichenbacher98.pdf)